### PR TITLE
Allow starting from checkpoints

### DIFF
--- a/core/argparser.py
+++ b/core/argparser.py
@@ -22,6 +22,9 @@ def parse_args():
     parser.add_argument('--buffer-capacity', type=int, help='The capacity to '
                         'use in the experience replay buffer. Default: %s'
                         % MEMORY_CAPACITY, default=MEMORY_CAPACITY)
+    parser.add_argument('--checkpoint', type=str, help='Specify a .dat file '
+                        'to be used as a checkpoint to initialize weights for '
+                        'a new training run. Defaults to no checkpoint.')
     parser.add_argument('--environment', type=str, help='The OpenAI gym '
                         'environment to use. Default: %s' % ENVIRONMENT,
                         default=ENVIRONMENT)

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -53,11 +53,20 @@ def set_device(force_cpu):
     return device
 
 
-def initialize_models(env, device):
+def load_model(checkpoint, model, target_model, device):
+    model.load_state_dict(torch.load(checkpoint, map_location=device))
+    target_model.load_state_dict(model.state_dict())
+    return model, target_model
+
+
+def initialize_models(env, device, checkpoint):
     model = CNNDQN(env.observation_space.shape,
                    env.action_space.n).to(device)
     target_model = CNNDQN(env.observation_space.shape,
                           env.action_space.n).to(device)
+    if checkpoint:
+        model, target_model = load_model(checkpoint, model, target_model,
+                                         device)
     return model, target_model
 
 

--- a/train.py
+++ b/train.py
@@ -70,7 +70,7 @@ def main():
     args = parse_args()
     env = wrap_environment(args.environment)
     device = set_device(args.force_cpu)
-    model, target_model = initialize_models(env, device)
+    model, target_model = initialize_models(env, device, args.checkpoint)
     optimizer = Adam(model.parameters(), lr=args.learning_rate)
     replay_buffer = ReplayBuffer(args.buffer_capacity)
     train(env, model, target_model, optimizer, replay_buffer, args, device)


### PR DESCRIPTION
Checkpoints allow a previously trained model to be used for a new training pass in transfer learning which allows re-training to be done faster.

Signed-Off-By: Robert Clark <robdclark@outlook.com>