### PR TITLE
Support Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot version updates allow updates to dependencies to be marked for updates when applicable.

Signed-Off-By: Robert Clark <robdclark@outlook.com>